### PR TITLE
정기결제 결제수단 변경시 장바구니가 비어 결제수단이 사라지던 버그 수정, 결제수단 변경시에도 카테고리 검사 되도록 추가

### DIFF
--- a/iamport-kakao.php
+++ b/iamport-kakao.php
@@ -362,9 +362,14 @@ class WC_Gateway_Iamport_Kakao extends Base_Gateway_Iamport {
     }
 
     public function kakao_unset_gateway_by_category($available_gateways) {
-        if ( ! is_checkout() ) return $available_gateways;
+        if ( !is_checkout() ) return $available_gateways;
         $cart_items = WC()->cart->get_cart();
-        if ( count($cart_items) == 0 )	return; //장바구니가 비어있으면 패스
+
+		// 정기결제 결제수단 변경의 경우 subscription id 가 change_payment_method에 포함되어 URL이 세팅됨
+		if (WC_Subscriptions_Change_Payment_Gateway::$is_request_to_change_payment) {
+			$subscription_obj = wcs_get_subscription($_GET['change_payment_method']);
+			$cart_items = $subscription_obj ->get_items();
+		}
 
         $categories = $this->get_display_categories();
         $disabled_categories = $this->get_disabled_categories();


### PR DESCRIPTION
if ( count($cart_items) == 0 ) return; //장바구니가 비어있으면 패스

이 코드가 결제수단 변경시 에러의 원인이었음.

또한 카카오페이는 특정 카테고리는 결제를 못하게 하는 처리가 있는데,
해당 검사에서 벌어진 일이므로, 정기결제 결제수단 변경시에도 카카오페이가 제대로 나오게 수정