### PR TITLE
신규 지점 오픈 추가(8/30)

### DIFF
--- a/NewIamportOrderRestController.php
+++ b/NewIamportOrderRestController.php
@@ -550,7 +550,7 @@ class NewIamportOrderRestController extends WP_REST_Controller
             case 'allspot':
                 return 3580;
             case 'seocho':
-                return 16;
+                return 3581;
             case 'hongdae':
                 return 3582;
             case 'yeouido':
@@ -559,6 +559,16 @@ class NewIamportOrderRestController extends WP_REST_Controller
                 return 3726;
             case 'hapjeong':
                 return 3727;
+            case 'yeoksam':
+                return 6180;
+            case 'yeongdeungpo':
+                return 9847;
+            case 'guro':
+                return 9848;
+            case 'yongsan':
+                return 9849;
+            case 'seolleung':
+                return 9850;
             default:
                 return null;
         }
@@ -581,6 +591,16 @@ class NewIamportOrderRestController extends WP_REST_Controller
                 return 'ONE SPOT 멤버십 - 반포 FIVE SPOT 전용';
             case 'hapjeong':
                 return 'ONE SPOT 멤버십 - 합정 FIVE SPOT 전용';
+            case 'yeoksam':
+                return 'ONE SPOT 멤버십 - 역삼 FIVE SPOT 전용';
+            case 'yeongdeungpo':
+                return 'ONE SPOT 멤버십 - 영등포 FIVE SPOT 전용';
+            case 'guro':
+                return 'ONE SPOT 멤버십 - 구로 FIVE SPOT 전용';
+            case 'yongsan':
+                return 'ONE SPOT 멤버십 - 용산 FIVE SPOT 전용';
+            case 'seolleung':
+                return 'ONE SPOT 멤버십 - 선릉 FIVE SPOT 전용';
             default:
                 return '';
             // case 'rounge' :


### PR DESCRIPTION
- 패스트파이브 신규 지점 5개 추가하였습니다(by @jangbora)
- 패스트파이브 워드프레스 어드민에 가보면 2.2.17 버전을 쓰고있는데 우리 SVN 레파지토리에는 tags/2.2.17은 없는 상태이고(무슨 일인지 없어짐...) NewIamportOrderRestController.php에는 추가된 신규 지점 5개에 대한 로직이 적용되어있는 상태입니다.
- 그런데 2.2.18 버전 이후 버전에는 NewIamportOrderRestController.php가 옛날 로직이 그대로 남아있는 상태라, 중간에 뭐가 꼬인 것 같습니다. 그래서 2.2.17에 반영된 것으로 추정되는 로직을 다시 반영하는 코드입니다.
- 패스트파이브 프론트 부분은 따로 레파지토리([ffpass-front](https://github.com/iamport/ffpass-front))가 존재하는데, 변경 요청 사항 적용하여 develop에 반영된 상태고 얘는 직접 빌드 후 패스트파이브 워드프레스 어드민에 접속해 템플릿 코드에 복붙해야합니다.