### PR TITLE
카테고리 미설정시 warning문구 나오는 현상 수정

### DIFF
--- a/iamport-kakao.php
+++ b/iamport-kakao.php
@@ -305,7 +305,7 @@ class WC_Gateway_Iamport_Kakao extends Base_Gateway_Iamport {
 		if ( !isset($this->settings['show_button_on_categories']) )		return 'all';
 
 		$categories = $this->settings['show_button_on_categories'];
-		if ( $categories === 'all' || in_array('all', $categories) )	return 'all';
+		if ( $categories === 'all' || ( is_array($categories) && in_array('all', $categories) ) )	return 'all';
 
 		return $categories;
 	}

--- a/iamport-kakao.php
+++ b/iamport-kakao.php
@@ -314,8 +314,8 @@ class WC_Gateway_Iamport_Kakao extends Base_Gateway_Iamport {
 		if ( !isset($this->settings['hide_button_on_categories']) )	return array();
 
 		$categories = $this->settings['hide_button_on_categories'];
-		if ( $categories === 'all' || in_array('all', $categories) )		return 'all';
-		if ( $categories === 'none' || in_array('none', $categories) )	return array();
+		if ( $categories === 'all' || ( is_array($categories) && in_array('all', $categories) ) )	return 'all';
+		if ( $categories === 'none' || ( is_array($categories) && in_array('none', $categories) ) )	return array();
 
 		return $categories;
 	}

--- a/iamport-naverpay-ext.php
+++ b/iamport-naverpay-ext.php
@@ -74,7 +74,7 @@ class WC_Gateway_Iamport_NaverPayExt extends Base_Gateway_Iamport {
       $allowed = explode(",", $debuggers);
       $login = wp_get_current_user();
 
-      if ( 0 == $login->ID || !in_array($login->user_login, $allowed) ) {
+      if ( 0 == $login->ID || ( is_array($allowed) && !in_array($login->user_login, $allowed) ) ) {
         unset($gateways[ $this->get_gateway_id() ]);
       }
     }
@@ -187,7 +187,7 @@ class WC_Gateway_Iamport_NaverPayExt extends Base_Gateway_Iamport {
       $iamport_naver_ctgr = isset( $_POST["term_meta"]["iamport_naver_ctgr"] ) ? sanitize_text_field( $_POST["term_meta"]["iamport_naver_ctgr"] ) : "";
       $categories = array_keys(self::$PRODUCT_CATEGORIES);
 
-      if ( "NONE" !== $iamport_naver_ctgr && in_array($iamport_naver_ctgr, $categories) ) {
+      if ( "NONE" !== $iamport_naver_ctgr && ( is_array($categories) && in_array($iamport_naver_ctgr, $categories) ) ) {
         $term_meta = array(
           "iamport_naver_ctgr" => $iamport_naver_ctgr
         );
@@ -316,7 +316,7 @@ class WC_Gateway_Iamport_NaverPayExt extends Base_Gateway_Iamport {
       $iamport_naver_ctgr = empty($term_meta["iamport_naver_ctgr"]) ? "" : $term_meta["iamport_naver_ctgr"];
       $categories = array_keys(self::$PRODUCT_CATEGORIES);
 
-      if ( "NONE" !== $iamport_naver_ctgr && in_array($iamport_naver_ctgr, $categories) ) {
+      if ( "NONE" !== $iamport_naver_ctgr && ( is_array($categories) && in_array($iamport_naver_ctgr, $categories) ) ) {
         $arr = explode("_", $iamport_naver_ctgr, 2); //처음만나는 _ 로만 잘라야 함
 
         return array(

--- a/iamport-naverpay.php
+++ b/iamport-naverpay.php
@@ -587,8 +587,8 @@ class WC_Gateway_Iamport_NaverPay extends Base_Gateway_Iamport {
 		if ( !isset($this->settings['disable_button_on_categories']) )	return array();
 
 		$categories = $this->settings['disable_button_on_categories'];
-		if ( $categories === 'all' || in_array('all', $categories) )		return 'all';
-		if ( $categories === 'none' || in_array('none', $categories) )	return array();
+		if ( $categories === 'all' || ( is_array($categories) && in_array('all', $categories) ) )	return 'all';
+		if ( $categories === 'none' || ( is_array($categories) && in_array('none', $categories) ) )	return array();
 
 		return $categories;
 	}

--- a/iamport-naverpay.php
+++ b/iamport-naverpay.php
@@ -578,7 +578,7 @@ class WC_Gateway_Iamport_NaverPay extends Base_Gateway_Iamport {
 		if ( !isset($this->settings['show_button_on_categories']) )		return array();
 
 		$categories = $this->settings['show_button_on_categories'];
-		if ( $categories === 'all' || in_array('all', $categories) )	return 'all';
+		if ( $categories === 'all' || ( is_array($categories) && in_array('all', $categories) ) )	return 'all';
 
 		return $categories;
 	}
@@ -993,11 +993,11 @@ class WC_Gateway_Iamport_NaverPay extends Base_Gateway_Iamport {
 		$cultureProducts = $this->get_attribute("culture_products");
 		$cultureCategories = $this->get_attribute("culture_categories");
 		if ( $cultureProducts || $cultureCategories ) {
-			$isProductNone = $cultureProducts === "none" || in_array("none", $cultureProducts);
-			$isCategoryNone = $cultureCategories === "none" || in_array("none", $cultureCategories);
+			$isProductNone = $cultureProducts === "none" || ( is_array($cultureProducts) && in_array("none", $cultureProducts) );
+			$isCategoryNone = $cultureCategories === "none" || ( is_array($cultureCategories) && in_array("none", $cultureCategories) );
 
-			$isProductAll = $cultureProducts === "all"  || in_array("all", $cultureProducts);
-			$isCategoryAll = $cultureCategories === "all"  || in_array("all", $cultureCategories);
+			$isProductAll = $cultureProducts === "all"  || ( is_array($cultureProducts) && in_array("all", $cultureProducts) );
+			$isCategoryAll = $cultureCategories === "all"  || ( is_array($cultureCategories) && in_array("all", $cultureCategories) );
 
 			if ( $isProductNone && $isCategoryNone )	return false;
 			if ( $isProductAll  || $isCategoryAll  )	return true;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26411995/143799789-d9c8de40-8132-454d-bb71-42381d68a390.png)

in_array를 array가 아닌 string일 때 동작하는 부분이 있음.
전체적인 동작에는 문제가 없으나(string일땐 in_array가 무조건 false여야 하므로)
WP_DEBUG가 true인 사용자에겐 버그로 인식되어 수정하였습니다.