### PR TITLE
feature: 아임포트 버전 세팅 가능하도록 설정 추가

### DIFF
--- a/IamportPlugin.php
+++ b/IamportPlugin.php
@@ -1287,8 +1287,12 @@ if(!function_exists('woocommerce_gateway_iamport_init')){
                 return false;
             }
 
-            public function enqueue_iamport_script() {
-                wp_register_script( 'woocommerce_iamport_script', 'https://cdn.iamport.kr/js/iamport.payment-1.1.7.js', array('jquery'), '20190812' );
+            public function enqueue_iamport_script() {		
+                $imp_version_setting = explode('/', get_option('woocommerce_iamport_sdk_version', '1.1.7/20190812'));
+                $imp_sdk_version = $imp_version_setting[0];
+                $imp_cache_version = $imp_version_setting[1] != 'latest' ? $imp_version_setting[1] : null;
+
+                wp_register_script( 'woocommerce_iamport_script', 'https://cdn.iamport.kr/js/iamport.payment-' . $imp_sdk_version . '.js', array('jquery'), $imp_cache_version );
                 wp_register_script( 'iamport_jquery_url', plugins_url( '/assets/js/url.min.js',plugin_basename(__FILE__) ), array(), '20190918');
                 wp_register_script( 'iamport_script_for_woocommerce', plugins_url( '/assets/js/iamport.woocommerce.js',plugin_basename(__FILE__) ), array('jquery', 'iamport_jquery_url'), '20200925');
                 wp_register_script( 'samsung_runnable', 'https://d3sfvyfh4b9elq.cloudfront.net/pmt/web/device.json' );

--- a/iamport-naverpay.php
+++ b/iamport-naverpay.php
@@ -1466,7 +1466,11 @@ class IamportNaverPayButton {
 			$button_color = strlen($style) > 1 ? substr($style, 1, 1) : "1";
 		}
 
-		wp_register_script( 'woocommerce_iamport_script', 'https://cdn.iamport.kr/js/iamport.payment-1.1.7.js', array('jquery'), '20190812' );
+		$imp_version_setting = explode('/', get_option('woocommerce_iamport_sdk_version', '1.1.7/20190812'));
+		$imp_sdk_version = $imp_version_setting[0];
+		$imp_cache_version = $imp_version_setting[1] != 'latest' ? $imp_version_setting[1] : null;
+
+		wp_register_script( 'woocommerce_iamport_script', 'https://cdn.iamport.kr/js/iamport.payment-' . $imp_sdk_version . '.js', array('jquery'), $imp_cache_version );
 		wp_register_script( 'naver_inflow_script', '//wcs.naver.net/wcslog.js' );
 
 		if ( wp_is_mobile() ) { //mobile

--- a/includes/IamportSettingTab.php
+++ b/includes/IamportSettingTab.php
@@ -30,6 +30,12 @@ class IamportSettingTab
         require_once(dirname(dirname(__FILE__)) . '/lib/IamportHelper.php');
 
         $custom_statuses = array_merge(array('none'=>'사용안함'), IamportHelper::getCustomStatuses());
+        $version_list = array(
+					'1.1.7/20190812'=>'1.1.7(2019.08.12)',
+					'1.1.7/latest'=>'1.1.7(latest)',
+					'1.1.8/latest'=>'1.1.8(latest)',
+					'1.2.0/latest'=>'1.2.0(latest)',
+				);
 
 		$settings = array(
 			array(
@@ -37,6 +43,14 @@ class IamportSettingTab
 				'type'		=> 'title',
 				'desc'		=> '',
 				'id'		=> 'wc_settings_tab_iamport_section_title'
+			),
+			array(
+				'title'		=> __( '아임포트 자바스크립트 SDK 버전', 'iamport-for-woocommerce' ),
+				'desc'    => __( '아임포트 모듈의 버전을 설정해주세요.<br> ㄴ 기본값은 1.1.7(2019.08.12)입니다<br> ㄴ 자세한 버전별 변경 내역은 <a target="_blank" href="https://docs.iamport.kr/sdk/release-notes">여기</a>를 참고해주세요.', 'iamport-for-woocommerce' ),
+				'id'		=> 'woocommerce_iamport_sdk_version',
+				'default'	=> '1.1.7/20190812',
+				'type'		=> 'select',
+                'options'   => $version_list,
 			),
 			array(
 				'title'		=> __( '자동 완료됨 처리', 'iamport-for-woocommerce' ),


### PR DESCRIPTION
가맹점 문의로 아임포트 모듈을 확인해본 결과,
무려 2019년 8월 12일자로 캐시가 걸려있는 아임포트 모듈을 사용하고 있었음.
기존 가맹점 하위호환을 위해, 설정값에서 아임포트 최신 버전으로 변경 가능하도록 기능을 추가하였습니다.

2021-12-06 추가
해당 부분이 이슈의 원인이 아닌 것으로 파악되어 hotfix에서 feature로 변경되었습니다.