### PR TITLE
feat: 네이버페이 useCfmYmdt 값을 설정에서 변경 가능하도록 수정

### DIFF
--- a/iamport-naverpay-ext.php
+++ b/iamport-naverpay-ext.php
@@ -119,6 +119,13 @@ class WC_Gateway_Iamport_NaverPayExt extends Base_Gateway_Iamport {
         'type' => 'text',
         'default' => "",
       ),
+      'useCfmYmdt' => array(
+        'title' => __( '이용완료일', 'iamport-for-woocommerce' ),
+        'label' => __( '이용완료일', 'iamport-for-woocommerce' ),
+        'description' => __( '이용완료일 기준 정산 및 포인트 적립 가맹점에서만 사용해주세요. (ex 20991231)', 'iamport-for-woocommerce' ),
+        'type' => 'text',
+        'default' => "",
+      ),
     ), $this->form_fields, array(
         'use_manual_pg' => array(
             'title' => __( 'PG설정 구매자 선택방식 사용', 'woocommerce' ),
@@ -250,7 +257,10 @@ class WC_Gateway_Iamport_NaverPayExt extends Base_Gateway_Iamport {
     }
 
     $response["naverProducts"] = $naverProducts;
-    $response["naverUseCfm"] = "20991231";
+    $naverUseCfm = $this->settings["useCfmYmdt"];
+    if ($naverUseCfm && $naverUseCfm != "") {
+      $response["naverUseCfm"] = $naverUseCfm;
+    }
     $response["unblock"] = true;
 
     if ( !wp_is_mobile() ) {

--- a/iamport-naverpay-ext.php
+++ b/iamport-naverpay-ext.php
@@ -119,10 +119,17 @@ class WC_Gateway_Iamport_NaverPayExt extends Base_Gateway_Iamport {
         'type' => 'text',
         'default' => "",
       ),
-      'useCfmYmdt' => array(
-        'title' => __( '이용완료일', 'iamport-for-woocommerce' ),
-        'label' => __( '이용완료일', 'iamport-for-woocommerce' ),
-        'description' => __( '이용완료일 기준 정산 및 포인트 적립 가맹점에서만 사용해주세요. (ex 20991231)', 'iamport-for-woocommerce' ),
+      'useCfm' => array(
+        'title' => __( '이용완료일 사용 여부', 'iamport-for-woocommerce' ),
+        'label' => __( '이용완료일 사용 여부', 'iamport-for-woocommerce' ),
+        'description' => __( '이용완료일 기준 정산 및 포인트 적립 가맹점에서만 사용해주세요', 'iamport-for-woocommerce' ),
+        'type' => 'checkbox',
+        'default' => "yes",
+      ),
+      'cfmYmdt' => array(
+        'title' => __( '이용완료일(yyyyMMdd)', 'iamport-for-woocommerce' ),
+        'label' => __( '이용완료일(yyyyMMdd)', 'iamport-for-woocommerce' ),
+        'description' => __( '사용 여부를 체크한 뒤 20991231와 같은 형식으로 적어주세요.', 'iamport-for-woocommerce' ),
         'type' => 'text',
         'default' => "20991231",
       ),
@@ -257,9 +264,11 @@ class WC_Gateway_Iamport_NaverPayExt extends Base_Gateway_Iamport {
     }
 
     $response["naverProducts"] = $naverProducts;
-    $naverUseCfm = $this->settings["useCfmYmdt"];
-    if ($naverUseCfm && $naverUseCfm != "") {
-      $response["naverUseCfm"] = $naverUseCfm;
+    $useCfm = $this->settings["useCfm"];
+    if (!isset($useCfm)) {
+      $response["naverUseCfm"] = "20991231";
+    } else if ($useCfm == 'yes') {
+      $response["naverUseCfm"] = $this->settings["cfmYmdt"];
     }
     $response["unblock"] = true;
 

--- a/iamport-naverpay-ext.php
+++ b/iamport-naverpay-ext.php
@@ -124,7 +124,7 @@ class WC_Gateway_Iamport_NaverPayExt extends Base_Gateway_Iamport {
         'label' => __( '이용완료일', 'iamport-for-woocommerce' ),
         'description' => __( '이용완료일 기준 정산 및 포인트 적립 가맹점에서만 사용해주세요. (ex 20991231)', 'iamport-for-woocommerce' ),
         'type' => 'text',
-        'default' => "",
+        'default' => "20991231",
       ),
     ), $this->form_fields, array(
         'use_manual_pg' => array(


### PR DESCRIPTION
네이버페이 결제형 결제시

현가맹점에 제공되지 않는 기능입니다.

라는 문구와 함께 실패하는 문의가 들어와 해당 기능과 관련있는 파라매터를 설정으로 뺐습니다.
naverUseCfm 초기값은 기존에 하드코딩으로 있던 20991231로 설정하였습니다. (업데이트 시 기존 가맹점 영향 최소화를 위해)